### PR TITLE
docs: document new district/subdistrict filters and examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,7 @@ go.work.sum
 
 
 data/*.sql
+
+# Local Go caches
+.gocache/
+.gomodcache/

--- a/README.md
+++ b/README.md
@@ -36,22 +36,35 @@ A high-performance, dependency-free Go API for fuzzy searching Indonesian admini
 
 ### Search Endpoint
 
-The general search endpoint now uses DuckDB's `match_bm25` function to perform a full-text search over a combined `full_text` field, which includes the province, city, district, and subdistrict names. This provides fast and relevant search results across all administrative levels.
+The general search endpoint supports both full-text and field-level fuzzy filters. Use any combination of the parameters below to narrow results.
 
-- **BM25 Full-Text Search**: The search is powered by the BM25 algorithm, which ranks results based on relevance to the query terms.
-- **Combined Text Field**: The `full_text` field is a concatenation of all administrative levels, allowing for a comprehensive search in a single query.
-- **Performance**: The query is highly optimized for performance, returning the top 10 results ordered by relevance score.
+- **BM25 Full-Text Search**: `q` uses DuckDB `match_bm25` over a combined `full_text` column.
+- **Field Fuzzy Filters**: `subdistrict`, `district`, `city`, `province` use Jaro-Winkler (≥ 0.8).
+- **Composable**: Combine parameters; scores are aggregated and results ordered by total score.
+- **City matching**: `city` matches both "Kota {name}" and "Kabupaten {name}" automatically.
+- **Performance**: Returns top 10 results.
 
 ```
-GET /v1/search?q={query}
+GET /v1/search?q={query}&subdistrict={name}&district={name}&city={name}&province={name}
 ```
 
 **Parameters:**
-- `q` (required): Search query string (e.g., "bandung")
+- `q` (optional): Full-text query (e.g., "bandung").
+- `subdistrict` (optional): Fuzzy filter for subdistrict.
+- `district` (optional): Fuzzy filter for district.
+- `city` (optional): Fuzzy filter for city/regency (no need to prefix with Kota/Kabupaten).
+- `province` (optional): Fuzzy filter for province.
 
-**Example Request:**
+**Example Requests:**
 ```bash
+# Full-text only
 curl "http://localhost:8080/v1/search?q=bandung"
+
+# Combine full-text with province filter
+curl "http://localhost:8080/v1/search?q=bandung&province=Jawa Barat"
+
+# Field-only filters (no q)
+curl "http://localhost:8080/v1/search?district=Cidadap&city=Bandung&province=Jawa Barat"
 ```
 
 **Example Response:**
@@ -78,60 +91,55 @@ curl "http://localhost:8080/v1/search?q=bandung"
 
 ### Specific Search Endpoints
 
-In addition to the general search endpoint, the API provides specific search endpoints for each administrative level:
+In addition to the general search endpoint, the API provides specific search endpoints for each administrative level. All use Jaro-Winkler fuzzy matching (≥ 0.8), order by similarity, and return up to 10 results.
 
-- **District Search**: `/v1/search/district?q={query}`
-- **Subdistrict Search**: `/v1/search/subdistrict?q={query}`
-- **City Search**: `/v1/search/city?q={query}`
-- **Province Search**: `/v1/search/province?q={query}`
+- **District Search**: `/v1/search/district?q={district}&city={city}&province={province}`
+  - `q` is required; `city` and `province` are optional narrowing filters.
+  - `city` matches both Kota and Kabupaten prefixes automatically.
 
-Each specific search endpoint:
-- Takes a required `q` query parameter containing the search term
-- Returns a JSON array of matching regions at that administrative level
-- Uses the Jaro-Winkler similarity algorithm for fuzzy matching with a threshold of 0.8 (80% similarity)
-- Orders results by similarity score in descending order (most similar first)
-- Limits results to 10 items per search
-- Returns the same Region structure as the general search endpoint
+- **Subdistrict Search**: `/v1/search/subdistrict?q={subdistrict}&district={district}&city={city}&province={province}`
+  - `q` is required; `district`, `city`, and `province` are optional narrowing filters.
+  - `city` matches both Kota and Kabupaten prefixes automatically.
+
+- **City Search**: `/v1/search/city?q={city}`
+  - `q` is required; matches both Kota and Kabupaten.
+
+- **Province Search**: `/v1/search/province?q={province}`
+  - `q` is required.
 
 #### District Search Endpoint
 
-Each specific search endpoint utilizes DuckDB's built-in `jaro_winkler_similarity` function to provide fuzzy matching capabilities:
-
-- **District Search** (`/v1/search/district?q={query}`): Compares the search query directly against the district names
-- **Subdistrict Search** (`/v1/search/subdistrict?q={query}`): Compares the search query directly against the subdistrict names
-- **Province Search** (`/v1/search/province?q={query}`): Compares the search query directly against the province names
-- **City Search** (`/v1/search/city?q={query}`): Compares the search query against both "Kota " + query and "Kabupaten " + query to match both city and regency names
-
-The Jaro-Winkler similarity algorithm is particularly effective for this use case because:
-- It gives more favorable ratings to strings that match from the beginning, which is ideal for geographical names
-- The 0.8 threshold ensures that only highly similar matches are returned (80% similarity or higher)
-- Results are ordered by similarity score in descending order, with the most similar matches appearing first
-- Each endpoint is limited to returning a maximum of 10 results to ensure fast response times
-
 ```
-GET /v1/search/district?q={query}
+GET /v1/search/district?q={district}&city={city}&province={province}
 ```
 
 **Parameters:**
-- `q` (required): Search query string (e.g., "bandung")
+- `q` (required): District name to match (e.g., "sukasari").
+- `city` (optional): Narrow by city/regency (no need for Kota/Kabupaten).
+- `province` (optional): Narrow by province.
 
-**Example Request:**
+**Example Requests:**
 ```bash
-curl "http://localhost:8080/v1/search/district?q=bandung"
+curl "http://localhost:8080/v1/search/district?q=Cidadap"
+curl "http://localhost:8080/v1/search/district?q=Cidadap&city=Bandung&province=Jawa Barat"
 ```
 
 #### Subdistrict Search Endpoint
 
 ```
-GET /v1/search/subdistrict?q={query}
+GET /v1/search/subdistrict?q={subdistrict}&district={district}&city={city}&province={province}
 ```
 
 **Parameters:**
-- `q` (required): Search query string (e.g., "sukasari")
+- `q` (required): Subdistrict name (e.g., "sukasari").
+- `district` (optional): Narrow by district.
+- `city` (optional): Narrow by city/regency (Kota/Kabupaten handled automatically).
+- `province` (optional): Narrow by province.
 
-**Example Request:**
+**Example Requests:**
 ```bash
-curl "http://localhost:8080/v1/search/subdistrict?q=sukasari"
+curl "http://localhost:8080/v1/search/subdistrict?q=Sukasari"
+curl "http://localhost:8080/v1/search/subdistrict?q=Sukasari&district=Sukasari&city=Bandung&province=Jawa Barat"
 ```
 
 #### City Search Endpoint

--- a/api.rest
+++ b/api.rest
@@ -13,11 +13,23 @@ GET {{baseUrl}}/v1/search?q=nonexistentplace123
 ### 3. District search endpoint with successful result
 GET {{baseUrl}}/v1/search/district?q=bandung
 
+### 3b. District search with city narrowing
+GET {{baseUrl}}/v1/search/district?q=bandung&city=bandung
+
+### 3c. District search with city and province narrowing
+GET {{baseUrl}}/v1/search/district?q=bandung&city=bandung&province=jawa%20barat
+
 ### 4. District search endpoint with no results
 GET {{baseUrl}}/v1/search/district?q=nonexistentdistrict123
 
 ### 5. Subdistrict search endpoint with successful result
 GET {{baseUrl}}/v1/search/subdistrict?q=menteng
+
+### 5b. Subdistrict search with district narrowing
+GET {{baseUrl}}/v1/search/subdistrict?q=menteng&district=tebet
+
+### 5c. Subdistrict search with district, city and province narrowing
+GET {{baseUrl}}/v1/search/subdistrict?q=menteng&district=tebet&city=jakarta%20selatan&province=dki%20jakarta
 
 ### 6. Subdistrict search endpoint with no results
 GET {{baseUrl}}/v1/search/subdistrict?q=nonexistentsubdistrict123

--- a/api.rest
+++ b/api.rest
@@ -10,6 +10,12 @@ GET {{baseUrl}}/v1/search?q='Perumahan Alam Citra 1 Jalan Liposos No15a RT10 Paa
 ### 2. General search endpoint with no results
 GET {{baseUrl}}/v1/search?q=nonexistentplace123
 
+### 2b. General search with province filter (BM25 + province fuzzy)
+GET {{baseUrl}}/v1/search?q=bandung&province=Jawa%20Barat
+
+### 2c. General search with only field filters (no q)
+GET {{baseUrl}}/v1/search?district=Cidadap&city=Bandung&province=Jawa%20Barat
+
 ### 3. District search endpoint with successful result
 GET {{baseUrl}}/v1/search/district?q=bandung
 
@@ -58,5 +64,11 @@ GET {{baseUrl}}/v1/search/postal/123
 ### 14. Postal code search endpoint with non-existent postal code
 GET {{baseUrl}}/v1/search/postal/99999
 
-### 15. General search endpoint with province specific and successful result
-GET {{baseUrl}}/v1/search?q=serang&subdistrict=bandng
+### 15. General search with province narrowing
+GET {{baseUrl}}/v1/search?q=serang&province=Banten
+
+### 16. General search with field-only narrowing (no q)
+GET {{baseUrl}}/v1/search?subdistrict=Sukasari&district=Sukasari&city=Bandung&province=Jawa%20Barat
+
+###
+GET {{baseUrl}}/v1/search?q='Jalan Phb Halong Atas Halong Teluk Ambon  gereja GMKI halong  Atas nama ade jesika'&district='teluk ambon'

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -66,23 +66,27 @@ func (h *Handler) SearchHandler() fiber.Handler {
 
 // DistrictSearchHandler handles the district search endpoint
 func (h *Handler) DistrictSearchHandler() fiber.Handler {
-	return func(c *fiber.Ctx) error {
-		// Extract and validate the q query parameter
-		query := c.Query("q")
-		if query == "" {
-			slog.Warn("District search query parameter missing", "ip", c.IP())
-			return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
-				"error": "Query parameter 'q' is required",
-			})
-		}
+    return func(c *fiber.Ctx) error {
+        // Extract and validate the q query parameter
+        query := c.Query("q")
+        if query == "" {
+            slog.Warn("District search query parameter missing", "ip", c.IP())
+            return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+                "error": "Query parameter 'q' is required",
+            })
+        }
 
-		// Use the service to perform the search
-		results, err := h.svc.SearchByDistrict(query)
-		if err != nil {
-			if service.IsError(err, service.ErrCodeInvalidInput) {
-				return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
-					"error": err.Error(),
-				})
+        // Optional narrowing filters
+        city := c.Query("city")
+        province := c.Query("province")
+
+        // Use the service to perform the search
+        results, err := h.svc.SearchByDistrict(query, city, province)
+        if err != nil {
+            if service.IsError(err, service.ErrCodeInvalidInput) {
+                return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+                    "error": err.Error(),
+                })
 			}
 			if service.IsError(err, service.ErrCodeDatabaseFailure) {
 				return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
@@ -102,23 +106,28 @@ func (h *Handler) DistrictSearchHandler() fiber.Handler {
 
 // SubdistrictSearchHandler handles the subdistrict search endpoint
 func (h *Handler) SubdistrictSearchHandler() fiber.Handler {
-	return func(c *fiber.Ctx) error {
-		// Extract and validate the q query parameter
-		query := c.Query("q")
-		if query == "" {
-			slog.Warn("Subdistrict search query parameter missing", "ip", c.IP())
-			return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
-				"error": "Query parameter 'q' is required",
-			})
-		}
+    return func(c *fiber.Ctx) error {
+        // Extract and validate the q query parameter
+        query := c.Query("q")
+        if query == "" {
+            slog.Warn("Subdistrict search query parameter missing", "ip", c.IP())
+            return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+                "error": "Query parameter 'q' is required",
+            })
+        }
 
-		// Use the service to perform the search
-		results, err := h.svc.SearchBySubdistrict(query)
-		if err != nil {
-			if service.IsError(err, service.ErrCodeInvalidInput) {
-				return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
-					"error": err.Error(),
-				})
+        // Optional narrowing filters
+        district := c.Query("district")
+        city := c.Query("city")
+        province := c.Query("province")
+
+        // Use the service to perform the search
+        results, err := h.svc.SearchBySubdistrict(query, district, city, province)
+        if err != nil {
+            if service.IsError(err, service.ErrCodeInvalidInput) {
+                return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+                    "error": err.Error(),
+                })
 			}
 			if service.IsError(err, service.ErrCodeDatabaseFailure) {
 				return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -156,72 +156,137 @@ func (s *Service) Search(searchQuery SearchQuery) ([]Region, error) {
 	return results, nil
 }
 
-// SearchByDistrict searches for regions by district name.
-func (s *Service) SearchByDistrict(query string) ([]Region, error) {
-	if query == "" {
-		return nil, NewError(ErrCodeInvalidInput, "query parameter is required")
-	}
+// SearchByDistrict searches for regions by district name, optionally narrowed by city and province.
+func (s *Service) SearchByDistrict(district string, city string, province string) ([]Region, error) {
+    if district == "" {
+        return nil, NewError(ErrCodeInvalidInput, "query parameter is required")
+    }
 
-	slog.Info("Processing district search request", "query", query)
+    slog.Info("Processing district search request", "district", district, "city", city, "province", province)
 
-	// Prepare and execute the SQL query
-	sqlQuery := `
-		SELECT id, subdistrict, district, city, province, postal_code, full_text
-		FROM regions
-		WHERE jaro_winkler_similarity (district, ?) >= 0.8
-		ORDER BY jaro_winkler_similarity (district, ?) DESC
-		LIMIT 10
-	`
+    // Build dynamic conditions and scoring based on provided filters
+    var conditions []string
+    var scoreComponents []string
+    var args []interface{}
+    var orderByArgs []interface{}
 
-	rows, err := s.db.Query(sqlQuery, query, query)
-	if err != nil {
-		slog.Error("Database query failed", "error", err, "query", query)
-		return nil, NewErrorf(ErrCodeDatabaseFailure, "database query failed: %v", err)
-	}
-	defer rows.Close()
+    // District is required
+    conditions = append(conditions, "jaro_winkler_similarity(district, ?) >= 0.8")
+    scoreComponents = append(scoreComponents, "jaro_winkler_similarity(district, ?)")
+    args = append(args, district)
+    orderByArgs = append(orderByArgs, district)
 
-	// Iterate through the results
-	results, err := s.scanRegions(rows)
-	if err != nil {
-		return nil, err
-	}
+    // Optional city filter (handles both Kota and Kabupaten prefixes)
+    if city != "" {
+        conditions = append(conditions, "(jaro_winkler_similarity(city, 'Kota ' || ?) >= 0.8 OR jaro_winkler_similarity(city, 'Kabupaten ' || ?) >= 0.8)")
+        scoreComponents = append(scoreComponents, "GREATEST(jaro_winkler_similarity(city, 'Kota ' || ?), jaro_winkler_similarity(city, 'Kabupaten ' || ?))")
+        args = append(args, city, city)
+        orderByArgs = append(orderByArgs, city, city)
+    }
 
-	slog.Info("District search completed", "query", query, "results", len(results))
-	return results, nil
+    // Optional province filter
+    if province != "" {
+        conditions = append(conditions, "jaro_winkler_similarity(province, ?) >= 0.8")
+        scoreComponents = append(scoreComponents, "jaro_winkler_similarity(province, ?)")
+        args = append(args, province)
+        orderByArgs = append(orderByArgs, province)
+    }
+
+    finalArgs := append(args, orderByArgs...)
+
+    sqlQuery := fmt.Sprintf(`
+        SELECT id, subdistrict, district, city, province, postal_code, full_text
+        FROM regions
+        WHERE %s
+        ORDER BY (%s) DESC
+        LIMIT 10
+    `, strings.Join(conditions, " AND "), strings.Join(scoreComponents, " + "))
+
+    rows, err := s.db.Query(sqlQuery, finalArgs...)
+    if err != nil {
+        slog.Error("Database query failed", "error", err, "district", district, "city", city, "province", province)
+        return nil, NewErrorf(ErrCodeDatabaseFailure, "database query failed: %v", err)
+    }
+    defer rows.Close()
+
+    // Iterate through the results
+    results, err := s.scanRegions(rows)
+    if err != nil {
+        return nil, err
+    }
+
+    slog.Info("District search completed", "district", district, "city", city, "province", province, "results", len(results))
+    return results, nil
 }
 
-// SearchBySubdistrict searches for regions by subdistrict name.
-func (s *Service) SearchBySubdistrict(query string) ([]Region, error) {
-	if query == "" {
-		return nil, NewError(ErrCodeInvalidInput, "query parameter is required")
-	}
+// SearchBySubdistrict searches for regions by subdistrict name, optionally narrowed by district, city, and province.
+func (s *Service) SearchBySubdistrict(subdistrict string, district string, city string, province string) ([]Region, error) {
+    if subdistrict == "" {
+        return nil, NewError(ErrCodeInvalidInput, "query parameter is required")
+    }
 
-	slog.Info("Processing subdistrict search request", "query", query)
+    slog.Info("Processing subdistrict search request", "subdistrict", subdistrict, "district", district, "city", city, "province", province)
 
-	// Prepare and execute the SQL query
-	sqlQuery := `
-		SELECT id, subdistrict, district, city, province, postal_code, full_text
-		FROM regions
-		WHERE jaro_winkler_similarity (subdistrict, ?) >= 0.8
-		ORDER BY jaro_winkler_similarity (subdistrict, ?) DESC
-		LIMIT 10
-	`
+    var conditions []string
+    var scoreComponents []string
+    var args []interface{}
+    var orderByArgs []interface{}
 
-	rows, err := s.db.Query(sqlQuery, query, query)
-	if err != nil {
-		slog.Error("Database query failed", "error", err, "query", query)
-		return nil, NewErrorf(ErrCodeDatabaseFailure, "database query failed: %v", err)
-	}
-	defer rows.Close()
+    // Required subdistrict condition
+    conditions = append(conditions, "jaro_winkler_similarity(subdistrict, ?) >= 0.8")
+    scoreComponents = append(scoreComponents, "jaro_winkler_similarity(subdistrict, ?)")
+    args = append(args, subdistrict)
+    orderByArgs = append(orderByArgs, subdistrict)
 
-	// Iterate through the results
-	results, err := s.scanRegions(rows)
-	if err != nil {
-		return nil, err
-	}
+    // Optional district filter
+    if district != "" {
+        conditions = append(conditions, "jaro_winkler_similarity(district, ?) >= 0.8")
+        scoreComponents = append(scoreComponents, "jaro_winkler_similarity(district, ?)")
+        args = append(args, district)
+        orderByArgs = append(orderByArgs, district)
+    }
 
-	slog.Info("Subdistrict search completed", "query", query, "results", len(results))
-	return results, nil
+    // Optional city filter (supports Kota/Kabupaten)
+    if city != "" {
+        conditions = append(conditions, "(jaro_winkler_similarity(city, 'Kota ' || ?) >= 0.8 OR jaro_winkler_similarity(city, 'Kabupaten ' || ?) >= 0.8)")
+        scoreComponents = append(scoreComponents, "GREATEST(jaro_winkler_similarity(city, 'Kota ' || ?), jaro_winkler_similarity(city, 'Kabupaten ' || ?))")
+        args = append(args, city, city)
+        orderByArgs = append(orderByArgs, city, city)
+    }
+
+    // Optional province filter
+    if province != "" {
+        conditions = append(conditions, "jaro_winkler_similarity(province, ?) >= 0.8")
+        scoreComponents = append(scoreComponents, "jaro_winkler_similarity(province, ?)")
+        args = append(args, province)
+        orderByArgs = append(orderByArgs, province)
+    }
+
+    finalArgs := append(args, orderByArgs...)
+
+    sqlQuery := fmt.Sprintf(`
+        SELECT id, subdistrict, district, city, province, postal_code, full_text
+        FROM regions
+        WHERE %s
+        ORDER BY (%s) DESC
+        LIMIT 10
+    `, strings.Join(conditions, " AND "), strings.Join(scoreComponents, " + "))
+
+    rows, err := s.db.Query(sqlQuery, finalArgs...)
+    if err != nil {
+        slog.Error("Database query failed", "error", err, "subdistrict", subdistrict, "district", district, "city", city, "province", province)
+        return nil, NewErrorf(ErrCodeDatabaseFailure, "database query failed: %v", err)
+    }
+    defer rows.Close()
+
+    // Iterate through the results
+    results, err := s.scanRegions(rows)
+    if err != nil {
+        return nil, err
+    }
+
+    slog.Info("Subdistrict search completed", "subdistrict", subdistrict, "district", district, "city", city, "province", province, "results", len(results))
+    return results, nil
 }
 
 // SearchByCity searches for regions by city name.
@@ -380,5 +445,3 @@ func (s *Service) scanRegions(rows *sql.Rows) ([]Region, error) {
 
 	return results, nil
 }
-
-

--- a/test_endpoints.sh
+++ b/test_endpoints.sh
@@ -14,6 +14,14 @@ echo "======================================"
 echo -e "\n1. Testing general search endpoint with successful result:"
 curl -s "http://${HOST}:${PORT}/v1/search?q=jakarta" | jq '.'
 
+# Test 1b: General search with province filter (BM25 + province fuzzy)
+echo -e "\n1b. Testing general search with province filter (BM25 + province fuzzy):"
+curl -s "http://${HOST}:${PORT}/v1/search?q=bandung&province=Jawa%20Barat" | jq '.'
+
+# Test 1c: General search with only field filters (no q)
+echo -e "\n1c. Testing general search with only field filters (no q):"
+curl -s "http://${HOST}:${PORT}/v1/search?district=Cidadap&city=Bandung&province=Jawa%20Barat" | jq '.'
+
 # Test 2: General search endpoint with no results
 echo -e "\n2. Testing general search endpoint with no results:"
 curl -s "http://${HOST}:${PORT}/v1/search?q=nonexistentplace123" | jq '.'
@@ -22,6 +30,14 @@ curl -s "http://${HOST}:${PORT}/v1/search?q=nonexistentplace123" | jq '.'
 echo -e "\n3. Testing district search endpoint with successful result:"
 curl -s "http://${HOST}:${PORT}/v1/search/district?q=bandung" | jq '.'
 
+# Test 3b: District search with city narrowing
+echo -e "\n3b. Testing district search with city narrowing:"
+curl -s "http://${HOST}:${PORT}/v1/search/district?q=bandung&city=serang" | jq '.'
+
+# Test 3c: District search with city and province narrowing
+echo -e "\n3c. Testing district search with city and province narrowing:"
+curl -s "http://${HOST}:${PORT}/v1/search/district?q=bandung&city=serang&province=banten" | jq '.'
+
 # Test 4: District search endpoint with no results
 echo -e "\n4. Testing district search endpoint with no results:"
 curl -s "http://${HOST}:${PORT}/v1/search/district?q=nonexistentdistrict123" | jq '.'
@@ -29,6 +45,14 @@ curl -s "http://${HOST}:${PORT}/v1/search/district?q=nonexistentdistrict123" | j
 # Test 5: Subdistrict search endpoint with successful result
 echo -e "\n5. Testing subdistrict search endpoint with successful result:"
 curl -s "http://${HOST}:${PORT}/v1/search/subdistrict?q=menteng" | jq '.'
+
+# Test 5b: Subdistrict search with district narrowing
+echo -e "\n5b. Testing subdistrict search with district narrowing:"
+curl -s "http://${HOST}:${PORT}/v1/search/subdistrict?q=menteng&district=tebet" | jq '.'
+
+# Test 5c: Subdistrict search with district, city and province narrowing
+echo -e "\n5c. Testing subdistrict search with district, city and province narrowing:"
+curl -s "http://${HOST}:${PORT}/v1/search/subdistrict?q=menteng&district=tebet&city=jakarta%20selatan&province=dki%20jakarta" | jq '.'
 
 # Test 6: Subdistrict search endpoint with no results
 echo -e "\n6. Testing subdistrict search endpoint with no results:"


### PR DESCRIPTION
Summary

- Adds documentation for composable filters on the general search endpoint.
- Documents optional narrowing filters for district and subdistrict endpoints.
- Updates API usage examples in README, api.rest, and test_endpoints.sh.

Changes

- README: clarify BM25 + Jaro-Winkler scoring; add combined filter examples.
- api.rest: add examples for mixed and field-only filters.
- test_endpoints.sh: add tests for new narrowing patterns.

API Updates

- General Search: GET /v1/search?q={query}&subdistrict={name}&district={name}&city={name}&province={name}
    - q: optional full-text (BM25).
    - subdistrict, district, city, province: optional fuzzy filters (Jaro-Winkler ≥ 0.8).
    - City matching automatically handles “Kota {name}” and “Kabupaten {name}”.
    - Returns top 10 results ordered by aggregate score.
    - Returns top 10 results ordered by aggregate score.
- District Search: GET /v1/search/district?q={district}&city={city}&province={province}
    - q: required.
    - city, province: optional narrowing filters.
- Subdistrict Search: GET /v1/search/subdistrict?q={subdistrict}&district={district}&city={city}&province={province}
    - q: required.
    - district, city, province: optional narrowing filters.

Examples
# General: full-text only
curl "http://localhost:8080/v1/search?q=bandung"

# General: BM25 + province narrowing
curl "http://localhost:8080/v1/search?q=bandung&province=Jawa%20Barat"

# General: field-only filters (no q)
curl "http://localhost:8080/v1/search?district=Cidadap&city=Bandung&province=Jawa%20Barat"

# District: with narrowing
curl "http://localhost:8080/v1/search/district?q=Cidadap&city=Bandung&province=Jawa%20Barat"
# Subdistrict: with narrowing
curl "http://localhost:8080/v1/search/subdistrict?q=Sukasari&district=Sukasari&city=Bandung&province=Jawa%20Barat"
Testing

- api.rest includes new example requests (2b, 2c, 15, 16).
- test_endpoints.sh adds:
    - 1b: General + province filter.
    - 1c: General with field-only filters.
    - 3b/3c: District with city and city+province narrowing.
    - 5b/5c: Subdistrict with district and district+city+province narrowing.

Notes

- Backward compatible: existing endpoints and the original q-only search continue to work.
- All fuzzy matches use Jaro-Winkler with threshold ≥ 0.8 and limit 10 results.