### PR TITLE
feat: add ngram utils package

### DIFF
--- a/pkg/utils/ngram/ngram.go
+++ b/pkg/utils/ngram/ngram.go
@@ -1,0 +1,407 @@
+package ngram
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"sort"
+	"strings"
+)
+
+// Result captures the outcome of a fuzzy search.
+type Result[T comparable] struct {
+	Item       T
+	Similarity float64
+}
+
+// Option configures an NGram instance during construction.
+type Option[T comparable] func(*NGram[T]) error
+
+// WithThreshold sets the minimum similarity required to include a result.
+func WithThreshold[T comparable](threshold float64) Option[T] {
+	return func(ng *NGram[T]) error {
+		if threshold < 0 || threshold > 1 {
+			return fmt.Errorf("threshold out of range 0.0 to 1.0: %v", threshold)
+		}
+		ng.threshold = threshold
+		return nil
+	}
+}
+
+// WithWarp increases the weight of shorter matches when greater than 1.0.
+func WithWarp[T comparable](warp float64) Option[T] {
+	return func(ng *NGram[T]) error {
+		if warp < 1.0 || warp > 3.0 {
+			return fmt.Errorf("warp out of range 1.0 to 3.0: %v", warp)
+		}
+		ng.warp = warp
+		return nil
+	}
+}
+
+// WithN configures the number of characters per n-gram window.
+func WithN[T comparable](n int) Option[T] {
+	return func(ng *NGram[T]) error {
+		if n < 1 {
+			return fmt.Errorf("N out of range (should be N >= 1): %d", n)
+		}
+		ng.N = n
+		return nil
+	}
+}
+
+// WithPadLen sets the number of padding characters to apply to each side.
+func WithPadLen[T comparable](padLen int) Option[T] {
+	return func(ng *NGram[T]) error {
+		if padLen < 0 {
+			return fmt.Errorf("pad_len out of range: %d", padLen)
+		}
+		ng.padLen = padLen
+		return nil
+	}
+}
+
+// WithPadChar configures the character used for padding.
+func WithPadChar[T comparable](padChar rune) Option[T] {
+	return func(ng *NGram[T]) error {
+		if padChar == 0 {
+			return errors.New("pad_char must be a valid rune")
+		}
+		ng.padChar = padChar
+		return nil
+	}
+}
+
+// WithKey registers a custom function for extracting the string key of an item.
+func WithKey[T comparable](key func(T) string) Option[T] {
+	return func(ng *NGram[T]) error {
+		if key == nil {
+			return errors.New("key function cannot be nil")
+		}
+		ng.key = key
+		return nil
+	}
+}
+
+// NGram implements fuzzy search over a set of comparable items using n-gram similarity.
+type NGram[T comparable] struct {
+	threshold float64
+	warp      float64
+	N         int
+	padLen    int
+	padChar   rune
+
+	key func(T) string
+
+	padding string
+	grams   map[string]map[T]int
+	length  map[T]int
+	items   map[T]struct{}
+}
+
+// New constructs an NGram index with the provided items and options.
+func New[T comparable](items []T, options ...Option[T]) (*NGram[T], error) {
+	ng := &NGram[T]{
+		threshold: 0,
+		warp:      1.0,
+		N:         3,
+		padLen:    -1,
+		padChar:   '$',
+		key:       defaultKey[T],
+		grams:     make(map[string]map[T]int),
+		length:    make(map[T]int),
+		items:     make(map[T]struct{}),
+	}
+
+	for _, opt := range options {
+		if err := opt(ng); err != nil {
+			return nil, err
+		}
+	}
+
+	if ng.padLen < 0 {
+		ng.padLen = ng.N - 1
+	}
+
+	if ng.padLen >= ng.N {
+		return nil, fmt.Errorf("pad_len out of range: %d", ng.padLen)
+	}
+
+	ng.padding = strings.Repeat(string(ng.padChar), ng.padLen)
+
+	if len(items) > 0 {
+		ng.Update(items)
+	}
+
+	return ng, nil
+}
+
+// Copy returns a shallow copy of the index configuration populated with the supplied items.
+func (ng *NGram[T]) Copy(items []T) (*NGram[T], error) {
+	clone, err := New[T](nil,
+		WithThreshold[T](ng.threshold),
+		WithWarp[T](ng.warp),
+		WithN[T](ng.N),
+		WithPadLen[T](ng.padLen),
+		WithPadChar[T](ng.padChar),
+		WithKey[T](ng.key),
+	)
+	if err != nil {
+		return nil, err
+	}
+	if len(items) == 0 {
+		items = ng.Items()
+	}
+	clone.Update(items)
+	return clone, nil
+}
+
+// Items returns a snapshot of all items stored in the index.
+func (ng *NGram[T]) Items() []T {
+	items := make([]T, 0, len(ng.items))
+	for item := range ng.items {
+		items = append(items, item)
+	}
+	return items
+}
+
+// Len reports the number of indexed items.
+func (ng *NGram[T]) Len() int {
+	return len(ng.items)
+}
+
+// Has reports whether the item has been indexed.
+func (ng *NGram[T]) Has(item T) bool {
+	_, ok := ng.items[item]
+	return ok
+}
+
+// Add inserts an item into the index if it is not already present.
+func (ng *NGram[T]) Add(item T) {
+	if ng.Has(item) {
+		return
+	}
+
+	key := ng.key(item)
+	padded := ng.pad(key)
+	grams := ng.split(padded)
+
+	ng.items[item] = struct{}{}
+	ng.length[item] = len([]rune(padded))
+
+	for _, gram := range grams {
+		bucket, ok := ng.grams[gram]
+		if !ok {
+			bucket = make(map[T]int)
+			ng.grams[gram] = bucket
+		}
+		bucket[item]++
+	}
+}
+
+// Update inserts every item in the slice into the index.
+func (ng *NGram[T]) Update(items []T) {
+	for _, item := range items {
+		ng.Add(item)
+	}
+}
+
+// Remove deletes the item from the index. It returns true when the item existed.
+func (ng *NGram[T]) Remove(item T) bool {
+	if !ng.Has(item) {
+		return false
+	}
+
+	delete(ng.items, item)
+	delete(ng.length, item)
+
+	padded := ng.pad(ng.key(item))
+	grams := ng.split(padded)
+	seen := make(map[string]struct{})
+
+	for _, gram := range grams {
+		if _, ok := seen[gram]; ok {
+			continue
+		}
+		seen[gram] = struct{}{}
+		if bucket, ok := ng.grams[gram]; ok {
+			delete(bucket, item)
+			if len(bucket) == 0 {
+				delete(ng.grams, gram)
+			}
+		}
+	}
+
+	return true
+}
+
+// Discard removes the item when present without reporting an error.
+func (ng *NGram[T]) Discard(item T) {
+	ng.Remove(item)
+}
+
+// Clear removes all indexed items.
+func (ng *NGram[T]) Clear() {
+	ng.items = make(map[T]struct{})
+	ng.grams = make(map[string]map[T]int)
+	ng.length = make(map[T]int)
+}
+
+// ItemsSharingNGrams returns the number of shared n-grams for every matching item.
+func (ng *NGram[T]) ItemsSharingNGrams(query string) map[T]int {
+	shared := make(map[T]int)
+	remaining := make(map[string]map[T]int)
+
+	for _, gram := range ng.split(ng.pad(query)) {
+		bucket, ok := ng.grams[gram]
+		if !ok {
+			continue
+		}
+
+		rem := remaining[gram]
+		if rem == nil {
+			rem = make(map[T]int)
+			remaining[gram] = rem
+		}
+
+		for item, count := range bucket {
+			if _, exists := rem[item]; !exists {
+				rem[item] = count
+			}
+			if rem[item] > 0 {
+				rem[item]--
+				shared[item]++
+			}
+		}
+	}
+
+	return shared
+}
+
+// Search returns the items whose similarity with the query is at least the provided threshold.
+func (ng *NGram[T]) Search(query string, threshold ...float64) []Result[T] {
+	if len(ng.items) == 0 {
+		return nil
+	}
+
+	min := ng.threshold
+	if len(threshold) > 0 {
+		min = threshold[0]
+	}
+
+	shared := ng.ItemsSharingNGrams(query)
+	if len(shared) == 0 {
+		return nil
+	}
+
+	paddedLen := len([]rune(ng.pad(query)))
+	results := make([]Result[T], 0, len(shared))
+
+	for item, samegrams := range shared {
+		allgrams := paddedLen + ng.length[item] - (2 * ng.N) - samegrams + 2
+		if allgrams <= 0 {
+			continue
+		}
+		similarity := Similarity(samegrams, allgrams, ng.warp)
+		if similarity >= min {
+			results = append(results, Result[T]{Item: item, Similarity: similarity})
+		}
+	}
+
+	sort.SliceStable(results, func(i, j int) bool {
+		if results[i].Similarity == results[j].Similarity {
+			return ng.key(results[i].Item) < ng.key(results[j].Item)
+		}
+		return results[i].Similarity > results[j].Similarity
+	})
+
+	return results
+}
+
+// SearchItem searches for items similar to the provided item.
+func (ng *NGram[T]) SearchItem(item T, threshold ...float64) []Result[T] {
+	return ng.Search(ng.key(item), threshold...)
+}
+
+// Find returns the closest match for the query along with a success flag.
+func (ng *NGram[T]) Find(query string, threshold ...float64) (T, bool) {
+	results := ng.Search(query, threshold...)
+	if len(results) == 0 {
+		var zero T
+		return zero, false
+	}
+	return results[0].Item, true
+}
+
+// FindItem returns the closest match for the item along with a success flag.
+func (ng *NGram[T]) FindItem(item T, threshold ...float64) (T, bool) {
+	return ng.Find(ng.key(item), threshold...)
+}
+
+// Compare returns the similarity between two strings using a temporary index.
+func Compare(s1, s2 string, options ...Option[string]) (float64, error) {
+	if s1 == s2 {
+		return 1.0, nil
+	}
+
+	ng, err := New[string]([]string{s1}, options...)
+	if err != nil {
+		return 0, err
+	}
+
+	results := ng.Search(s2)
+	if len(results) == 0 {
+		return 0, nil
+	}
+	return results[0].Similarity, nil
+}
+
+// Similarity computes the n-gram similarity score.
+func Similarity(samegrams, allgrams int, warp float64) float64 {
+	if allgrams <= 0 {
+		return 0
+	}
+
+	if math.Abs(warp-1.0) < 1e-9 {
+		return float64(samegrams) / float64(allgrams)
+	}
+
+	diffgrams := float64(allgrams - samegrams)
+	numerator := math.Pow(float64(allgrams), warp) - math.Pow(diffgrams, warp)
+	denominator := math.Pow(float64(allgrams), warp)
+	if denominator == 0 {
+		return 0
+	}
+	return numerator / denominator
+}
+
+func (ng *NGram[T]) pad(s string) string {
+	if ng.padLen == 0 {
+		return s
+	}
+	return ng.padding + s + ng.padding
+}
+
+func (ng *NGram[T]) split(s string) []string {
+	runes := []rune(s)
+	if len(runes) < ng.N {
+		return nil
+	}
+
+	grams := make([]string, 0, len(runes)-ng.N+1)
+	for i := 0; i <= len(runes)-ng.N; i++ {
+		grams = append(grams, string(runes[i:i+ng.N]))
+	}
+	return grams
+}
+
+func defaultKey[T comparable](item T) string {
+	switch v := any(item).(type) {
+	case string:
+		return v
+	case fmt.Stringer:
+		return v.String()
+	default:
+		return fmt.Sprint(v)
+	}
+}

--- a/pkg/utils/ngram/ngram_test.go
+++ b/pkg/utils/ngram/ngram_test.go
@@ -1,0 +1,210 @@
+package ngram
+
+import (
+	"math"
+	"strings"
+	"testing"
+)
+
+func TestSearchExamples(t *testing.T) {
+	ng, err := New([]string{"SPAM", "SPAN", "EG"})
+	if err != nil {
+		t.Fatalf("New returned error: %v", err)
+	}
+
+	results := ng.Search("SPA")
+	if len(results) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(results))
+	}
+	if results[0].Item != "SPAM" || !almostEqual(results[0].Similarity, 0.375) {
+		t.Fatalf("unexpected first result: %+v", results[0])
+	}
+	if results[1].Item != "SPAN" || !almostEqual(results[1].Similarity, 0.375) {
+		t.Fatalf("unexpected second result: %+v", results[1])
+	}
+
+	results = ng.Search("M")
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if results[0].Item != "SPAM" || !almostEqual(results[0].Similarity, 0.125) {
+		t.Fatalf("unexpected result for query M: %+v", results[0])
+	}
+
+	results = ng.Search("EG")
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result for EG, got %d", len(results))
+	}
+	if results[0].Item != "EG" || !almostEqual(results[0].Similarity, 1.0) {
+		t.Fatalf("unexpected result for query EG: %+v", results[0])
+	}
+}
+
+func TestCompareExamples(t *testing.T) {
+	cases := []struct {
+		name string
+		a    string
+		b    string
+		opts []Option[string]
+		want float64
+	}{
+		{name: "spa-spam", a: "spa", b: "spam", want: 0.375},
+		{name: "ham-bam", a: "ham", b: "bam", want: 0.25},
+		{name: "spam-pam", a: "spam", b: "pam", opts: []Option[string]{WithN[string](2)}, want: 0.5},
+		{name: "ham-ams", a: "ham", b: "ams", opts: []Option[string]{WithN[string](1)}, want: 0.5},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := Compare(tc.a, tc.b, tc.opts...)
+			if err != nil {
+				t.Fatalf("Compare returned error: %v", err)
+			}
+			if !almostEqual(got, tc.want) {
+				t.Fatalf("Compare(%q, %q) = %f, want %f", tc.a, tc.b, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestFindExamples(t *testing.T) {
+	ng, err := New([]string{"Spam", "Eggs", "Ham"}, WithKey[string](func(s string) string {
+		return strings.ToLower(s)
+	}), WithN[string](1))
+	if err != nil {
+		t.Fatalf("New returned error: %v", err)
+	}
+
+	if got, ok := ng.Find("Hom"); !ok || got != "Ham" {
+		t.Fatalf("Find(\"Hom\") = %q, %v", got, ok)
+	}
+
+	if got, ok := ng.Find("Spom"); !ok || got != "Spam" {
+		t.Fatalf("Find(\"Spom\") = %q, %v", got, ok)
+	}
+
+	if _, ok := ng.Find("Spom", 0.8); ok {
+		t.Fatalf("expected Find with threshold 0.8 to fail")
+	}
+}
+
+func TestSearchItemWithStructKey(t *testing.T) {
+	type entry struct {
+		id   int
+		name string
+	}
+
+	items := []entry{
+		{id: 1, name: "SPAM"},
+		{id: 2, name: "SPAN"},
+		{id: 3, name: "EG"},
+	}
+
+	ng, err := New(items, WithKey[entry](func(e entry) string { return e.name }))
+	if err != nil {
+		t.Fatalf("New returned error: %v", err)
+	}
+
+	results := ng.SearchItem(entry{name: "SPA"})
+	if len(results) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(results))
+	}
+	if results[0].Item.id != 1 || results[1].Item.id != 2 {
+		t.Fatalf("unexpected item order: %+v", results)
+	}
+
+	if found, ok := ng.FindItem(entry{name: "EG"}); !ok || found.id != 3 {
+		t.Fatalf("FindItem returned unexpected result: %+v, %v", found, ok)
+	}
+}
+
+func TestRemoveAndClear(t *testing.T) {
+	ng, err := New([]string{"spam", "eggs"})
+	if err != nil {
+		t.Fatalf("New returned error: %v", err)
+	}
+
+	if removed := ng.Remove("spam"); !removed {
+		t.Fatalf("expected spam to be removed")
+	}
+
+	if results := ng.Search("spam"); len(results) != 0 {
+		t.Fatalf("expected no results after removal, got %+v", results)
+	}
+
+	ng.Clear()
+	if ng.Len() != 0 {
+		t.Fatalf("expected Len() = 0 after Clear(), got %d", ng.Len())
+	}
+}
+
+func TestItemsSharingNGrams(t *testing.T) {
+	ng, err := New([]string{"ham", "spam", "eggs"})
+	if err != nil {
+		t.Fatalf("New returned error: %v", err)
+	}
+
+	shared := ng.ItemsSharingNGrams("mam")
+	if len(shared) != 2 {
+		t.Fatalf("expected 2 matches, got %d", len(shared))
+	}
+
+	if shared["ham"] != 2 {
+		t.Fatalf("expected ham to share 2 n-grams, got %d", shared["ham"])
+	}
+	if shared["spam"] != 2 {
+		t.Fatalf("expected spam to share 2 n-grams, got %d", shared["spam"])
+	}
+}
+
+func TestOptionValidation(t *testing.T) {
+	if _, err := New([]string{"a"}, WithThreshold[string](-0.1)); err == nil {
+		t.Fatalf("expected WithThreshold to reject negative value")
+	}
+
+	if _, err := New([]string{"a"}, WithWarp[string](0.5)); err == nil {
+		t.Fatalf("expected WithWarp to reject value below 1")
+	}
+
+	if _, err := New([]string{"a"}, WithN[string](0)); err == nil {
+		t.Fatalf("expected WithN to reject value below 1")
+	}
+
+	if _, err := New([]string{"a"}, WithPadLen[string](-1)); err == nil {
+		t.Fatalf("expected WithPadLen to reject negative value")
+	}
+
+	if _, err := New([]string{"a"}, WithPadChar[string](0)); err == nil {
+		t.Fatalf("expected WithPadChar to reject zero rune")
+	}
+
+	if _, err := New([]string{"a"}, WithKey[string](nil)); err == nil {
+		t.Fatalf("expected WithKey to reject nil function")
+	}
+}
+
+func TestSimilarityWarp(t *testing.T) {
+	cases := []struct {
+		same int
+		all  int
+		warp float64
+		want float64
+	}{
+		{same: 5, all: 10, warp: 1, want: 0.5},
+		{same: 5, all: 10, warp: 2, want: 0.75},
+		{same: 5, all: 10, warp: 3, want: 0.875},
+		{same: 2, all: 4, warp: 2, want: 0.75},
+		{same: 3, all: 4, warp: 1, want: 0.75},
+	}
+
+	for _, tc := range cases {
+		got := Similarity(tc.same, tc.all, tc.warp)
+		if !almostEqual(got, tc.want) {
+			t.Fatalf("Similarity(%d, %d, %f) = %f, want %f", tc.same, tc.all, tc.warp, got, tc.want)
+		}
+	}
+}
+
+func almostEqual(a, b float64) bool {
+	return math.Abs(a-b) < 1e-9
+}


### PR DESCRIPTION
## Summary
- add a generic n-gram index with configurable options for threshold, warp, padding, and key extraction
- expose fuzzy search helpers including search, find, and similarity utilities plus string comparison support
- cover the new package with tests that mirror the reference Python behaviour and validate option validation paths

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68cebcb977f8832fbcc63d77e343678e