### PR TITLE
fix: bundle ca certificates in docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,9 @@ WORKDIR /app
 # Copy the binary from builder stage
 COPY --from=builder /app/regions-api .
 
+# Copy CA certificates so DuckDB can download extensions over HTTPS
+COPY --from=builder /etc/ssl/certs /etc/ssl/certs
+
 # Copy the database file
 COPY --from=builder /app/data/regions.duckdb ./data/regions.duckdb
 


### PR DESCRIPTION
## Summary
- copy the CA certificate bundle from the builder stage into the runtime image so DuckDB can download extensions when the container starts

## Testing
- go test ./... *(hangs locally during DuckDB build; aborted)*

------
https://chatgpt.com/codex/tasks/task_e_68d90bda444c832fb1f7f8151fcaf05c